### PR TITLE
Created in "strict-di" mode;

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,7 +15,9 @@ define('chartIQ', ['chartiq'], function (chartiq) {
 
 // Require the AMD module then bootstrap the app after the library is loaded
 require(['chartIQ'], function(){
-	angular.bootstrap(document,['cqNgApp']);
+	angular.bootstrap(document,['cqNgApp'], {
+		strictDi: true
+	});
 });
 
 // Create the app module


### PR DESCRIPTION
[strict-di mode instruction](https://docs.angularjs.org/api/ng/directive/ngApp)

if this attribute is present on the app element, the injector will be created in "strict-di" mode. This means that the application will fail to invoke functions which do not use explicit function annotation (and are thus unsuitable for minification), as described in the Dependency Injection guide, and useful debugging info will assist in tracking down the root of these bugs.